### PR TITLE
Issue #6 Add GitHub Actions workflow for .NET project build

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,29 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    # TODO: Create tests and uncomment the test step
+    #- name: Test
+    #  run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
This pull request closes #6 

Introduces a new GitHub Actions workflow to build a .NET project. The workflow is configured to trigger on pushes and pull requests to the `main` branch.