### PR TITLE
Issue #10 add ship class

### DIFF
--- a/CipherSink/Models/OccupationType.cs
+++ b/CipherSink/Models/OccupationType.cs
@@ -11,6 +11,21 @@ namespace CipherSink.Models;
 /// </summary>
 public enum  OccupationType
 {
+    [Description("C")]
+    Carrier,
+
+    [Description("B")]
+    Battleship,
+
+    [Description("C")]
+    Cruiser,
+
+    [Description("S")]
+    Submarine,
+
+    [Description("D")]
+    Destroyer,
+
     [Description("o")]
     Empty,
 

--- a/CipherSink/Models/Ships/Ship.cs
+++ b/CipherSink/Models/Ships/Ship.cs
@@ -26,7 +26,7 @@ internal abstract class Ship
     /// <summary>
     /// The size of the ship, which is the number of cells it occupies on the game board.
     /// </summary>
-    public required int Size { get; init; }
+    public int Size { get; init; }
 
     /// <summary>
     /// The occupation type of the ship, represented by the OccupationType enum.

--- a/CipherSink/Models/Ships/Ship.cs
+++ b/CipherSink/Models/Ships/Ship.cs
@@ -1,0 +1,87 @@
+﻿namespace CipherSink.Models.Ships;
+
+/// <summary>
+/// This class represents a ship on the game board.
+/// </summary>
+internal abstract class Ship
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Ship"/> class with the specified name, size, and occupation type.
+    /// </summary>
+    /// <param name="name">The name of the ship. Cannot be null or empty.</param>
+    /// <param name="size">The size of the ship as an int, representing the number of cells it occupies.</param>
+    /// <param name="occupation">The occupation type of the ship</param>
+    protected Ship(string name, int size, OccupationType occupation)
+    {
+        Name = name;
+        Size = size;
+        Occupation = occupation;
+    }
+
+    /// <summary>
+    /// The name of the ship, stored as a string
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The size of the ship, which is the number of cells it occupies on the game board.
+    /// </summary>
+    public required int Size { get; init; }
+
+    /// <summary>
+    /// The occupation type of the ship, represented by the OccupationType enum.
+    /// </summary>
+    public OccupationType Occupation { get; init; }
+
+    /// <summary>
+    /// A list of coordinates representing the positions occupied by the ship on the game board.
+    /// </summary>
+    public IReadOnlyList<Coordinates> Positions { get; protected set; } = new List<Coordinates>();
+
+    /// <summary>
+    /// A HashSet of coordinates representing the cells of the ship that have been hit
+    /// </summary>
+    private readonly HashSet<Coordinates> Hits = new();
+
+    /// <summary>
+    /// public property to access the hit positions of the ship.
+    /// </summary>
+    public IReadOnlyCollection<Coordinates> HitPositions => Hits;
+
+    /// <summary>
+    /// boolean indicating whether the ship is sunk or not.
+    /// if the number of hits equals the size of the ship, it is considered sunk.
+    /// </summary>
+    public bool IsSunk => Hits.Count == Size;
+
+    /// <summary>
+    /// Adds a coordinate to Hits if it is a valid position of the ship.
+    /// </summary>
+    /// <param name="coordinates"></param>
+    public void RegisterHit(Coordinates coordinates)
+    {
+        if (Positions.Contains(coordinates))
+        {
+            Hits.Add(coordinates);
+        }
+    }
+
+    /// <summary>
+    /// Sets the positions of the ship on the game board.
+    /// </summary>
+    /// <param name="positions">The list of coordinates the ship is placed at</param>
+    public void SetPositions(List<Coordinates> positions)
+    {
+        if (Positions.Count > 0)
+        {
+            throw new InvalidOperationException($"Positions have already been set for ship: {Name}");
+        }
+
+        if (positions.Count != Size)
+        {
+            throw new ArgumentException($"The number of positions must be equal to the size of the ship ({Size}).");
+        }
+
+        Positions = positions;
+    }
+}

--- a/CipherSink/Models/Ships/Ship.cs
+++ b/CipherSink/Models/Ships/Ship.cs
@@ -21,7 +21,7 @@ internal abstract class Ship
     /// <summary>
     /// The name of the ship, stored as a string
     /// </summary>
-    public required string Name { get; init; }
+    public string Name { get; init; }
 
     /// <summary>
     /// The size of the ship, which is the number of cells it occupies on the game board.

--- a/CipherSink/Models/Ships/Ships.cs
+++ b/CipherSink/Models/Ships/Ships.cs
@@ -1,0 +1,26 @@
+﻿namespace CipherSink.Models.Ships;
+
+internal class Carrier : Ship
+{
+    public Carrier() : base("Carrier", 5, OccupationType.Carrier) { }
+}
+
+internal class Battleship : Ship
+{
+    public Battleship() : base("Battleship", 4, OccupationType.Battleship) { }
+}
+
+internal class Cruiser : Ship
+{
+    public Cruiser() : base("Cruiser", 3, OccupationType.Cruiser) { }
+}
+
+internal class Submarine : Ship
+{
+    public Submarine() : base("Submarine", 3, OccupationType.Submarine) { }
+}
+
+internal class Destroyer : Ship
+{
+    public Destroyer() : base("Destroyer", 2, OccupationType.Destroyer) { }
+}


### PR DESCRIPTION
This pull request closes #10 

Add an abstract `Ship` class, specific ship types, and updating the `OccupationType` enum to include these new ship types.

### New Ship Class

* **Addition of `Ship` Base Class**: Introduced an abstract `Ship` class to represent ships on the game board. This class includes properties for the ship's name, size, occupation type, positions, and hit tracking, as well as methods for registering hits and setting positions. (`CipherSink/Models/Ships/Ship.cs`)
* **Specific Ship Types**: Added concrete classes (`Carrier`, `Battleship`, `Cruiser`, `Submarine`, `Destroyer`) that inherit from the `Ship` base class, each with predefined names, sizes, and occupation types. (`CipherSink/Models/Ships/Ships.cs`)

### Updates to Enums:

* **Expansion of `OccupationType` Enum**: Updated the `OccupationType` enum to include new entries for `Carrier`, `Battleship`, `Cruiser`, `Submarine`, and `Destroyer`, each with a corresponding description. (`CipherSink/Models/OccupationType.cs`)