### PR TITLE
Issue #25 Moved Enums into GameBoard folder

### DIFF
--- a/CipherSink/Helpers/OccupationTypeExtension.cs
+++ b/CipherSink/Helpers/OccupationTypeExtension.cs
@@ -1,4 +1,4 @@
-﻿using CipherSink.Models;
+﻿using CipherSink.Models.GameBoard;
 using System.ComponentModel;
 
 namespace CipherSink.Helpers;

--- a/CipherSink/Models/GameBoard/Enums.cs
+++ b/CipherSink/Models/GameBoard/Enums.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace CipherSink.Models;
+namespace CipherSink.Models.GameBoard;
 
 /// <summary>
 /// CheckCellResult enumeration represents the result of checking a cell in the game board.


### PR DESCRIPTION
This pull request reorganizes the project structure by moving game board-related models into a dedicated namespace and directory. The most important changes include updating namespace references and renaming the `Enums.cs` file to better reflect its purpose.

### Namespace and file structure reorganization:

* [`CipherSink/Helpers/OccupationTypeExtension.cs`](diffhunk://#diff-ca21d779af718da6fdb25cbb9fd8a299d36c64b65f68cf79d419f7eb275ec90cL1-R1): Updated the namespace reference for `CipherSink.Models` to `CipherSink.Models.GameBoard` to align with the new directory structure.
* [`CipherSink/Models/GameBoard/Enums.cs`](diffhunk://#diff-b6adaefb967481384db9737ade01fb79a7878dd7f59a38d3b3532e58e86da234L3-R3): Renamed the file from `CipherSink/Models/Enums.cs` to `CipherSink/Models/GameBoard/Enums.cs` and updated its namespace from `CipherSink.Models` to `CipherSink.Models.GameBoard`.