### PR TITLE
Issue #30 lock ships

### DIFF
--- a/CipherSink/Models/GameBoard/GameBoard.cs
+++ b/CipherSink/Models/GameBoard/GameBoard.cs
@@ -102,9 +102,7 @@ internal class GameBoard
             Grid[placeX, placeY].OccupationType = ship.OccupationType;
             positions.Add(new Coordinates(placeX, placeY));
         }
-        ship.SetPositions(positions);
-
-        return true;
+        return ship.SetPositions(positions);
     }
 
     /// <summary>
@@ -132,6 +130,24 @@ internal class GameBoard
                 throw new InvalidOperationException($"Could not place ship: {ship.Name} after {attempts} attempts.");
             }
         }
+    }
+
+    public bool LockShips() 
+    {
+        // Lock all ships to prevent further placement
+        foreach (var ship in Ships)
+        {
+            if (!ship.IsLocked)
+            {
+                bool success = ship.LockPositions();
+                if (!success)
+                {
+                    return false; // If any ship fails to lock, return false
+                }
+            }
+        }
+
+        return true; // All ships successfully locked
     }
 
     /// <summary>

--- a/CipherSink/Models/GameBoard/Ships.cs
+++ b/CipherSink/Models/GameBoard/Ships.cs
@@ -54,6 +54,8 @@ internal abstract class Ship
     /// </summary>
     public bool IsSunk => Hits.Count == Size;
 
+    public bool IsLocked { get; protected set; } = false;
+
     /// <summary>
     /// Adds a coordinate to Hits if it is a valid position of the ship.
     /// </summary>
@@ -70,11 +72,11 @@ internal abstract class Ship
     /// Sets the positions of the ship on the game board.
     /// </summary>
     /// <param name="positions">The list of coordinates the ship is placed at</param>
-    public void SetPositions(List<Coordinates> positions)
+    public bool SetPositions(List<Coordinates> positions)
     {
-        if (Positions.Count > 0)
+        if (positions == null)
         {
-            throw new InvalidOperationException($"Positions have already been set for ship: {Name}");
+            throw new ArgumentNullException(nameof(positions), "Positions cannot be null.");
         }
 
         if (positions.Count != Size)
@@ -82,7 +84,34 @@ internal abstract class Ship
             throw new ArgumentException($"The number of positions must be equal to the size of the ship ({Size}).");
         }
 
-        Positions = positions;
+        if (IsLocked)
+        {
+            return false;
+        }
+
+        Positions = new List<Coordinates>(positions).AsReadOnly();
+        return true;
+    }
+
+    public bool LockPositions()
+    {
+        if (Positions.Count == 0)
+        {
+            return false;
+        }
+
+        IsLocked = true;
+        return true;
+    }
+
+    public bool LockPositions(List<Coordinates> positions)
+    {
+        if (SetPositions(positions))
+        {
+            return LockPositions();
+        }
+
+        return false;
     }
 }
 


### PR DESCRIPTION
This pull request introduces changes to ship placement and locking mechanisms in the game board logic. 
### Enhancements to ship placement and locking:

- **Added ship locking functionality**: Introduced the `IsLocked` property to the `Ship` class to prevent further modifications to a ship's position once locked. Added methods `LockPositions()` and `LockPositions(List<Coordinates>)` to lock ship positions securely. [[1]](diffhunk://#diff-5e22dcf106c22c5ce88005737b053e14096254a1c9894955665e1e54a9f80671R57-R58) [[2]](diffhunk://#diff-5e22dcf106c22c5ce88005737b053e14096254a1c9894955665e1e54a9f80671L73-R114)
- **Modified `SetPositions` method**: Changed the method to return a boolean indicating success or failure, added validation for null positions, and ensured positions cannot be set if the ship is locked.

### Updates to game board logic:

- **Refactored `PlaceShip` method**: Updated the method to return the result of `ship.SetPositions(positions)` instead of always returning `true`, allowing for better error handling and alignment with the new locking mechanism.
- **Introduced `LockShips` method**: Added a method to lock all ships on the game board, ensuring no further placement changes can occur. This method validates the locking process and returns `false` if any ship fails to lock.